### PR TITLE
[util] set enableDialogMode for Indiana Jones Emperor's Tomb

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -646,6 +646,11 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                "60"   },
       { "d3d8.forceD16",                    "True" },
     }} },
+    /* Indiana Jones and the Emperor's Tomb      *
+     * Fixes intro window being stuck on screen  */
+    { R"(\\indy\.exe$)", {{
+      { "d3d9.enableDialogMode",            "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Without this the separate window where the intro videos play stays stuck on screen in front of the game.

<details>
  <summary>Screenshot</summary>

![Screenshot_20221022_121826](https://user-images.githubusercontent.com/47954800/197335459-cb48a95b-44c0-493e-82dd-5dfab366b32b.png)
</details>