### PR TITLE
Use at least one BackBuffer in D3D8DeviceEx

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -70,6 +70,9 @@ namespace dxvk {
       D3DRS_PATCHSEGMENTS
     );
 
+    // Mirrors how D3D9 handles the BackBufferCount
+    m_presentParams.BackBufferCount = std::max(m_presentParams.BackBufferCount, 1u);
+
     m_textures.fill(nullptr);
     m_streams.fill(D3D8VBO());
 


### PR DESCRIPTION
Gets Red Faction going up to the game menu and mirrors what D3D9 does. I *think* I'm doing the right thing here, but please treat all my PRs as unexploded ordnance.

This was discovered while investigating a crash in IDirect3DDevice8::GetBackBuffer. Red Faction will create a IDirect3DDevice8 with BackBufferCount = 0, then call GetBackBuffer for iBackBuffer = 0, which would try to assign it on top of an out of bounds vector index.

P.S.: Apparently also fixes #79 :tada: 