### PR TITLE
Add memoryTrackTest & memory limit workarounds for Anito

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -705,6 +705,11 @@ namespace dxvk {
     { R"(\\splintercell\.exe$)", {{
       { "d3d8.useShadowBuffers",            "True" },
     }} },
+    /* Anito: Defend a Land Enraged              */
+    { R"(\\Anito\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "1024" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #71. Tested with the game demo provided by the reporter - it appears to work fine otherwise.

![Anito](https://user-images.githubusercontent.com/6306593/214870931-4e847183-c7ec-417b-8e3e-bad29ab4ff7b.png)

The game will call **IDirect3DDevice8::GetAvailableTextureMem** and crash if that returns more than the game expects (a 1024 limit works and sounds reasonable for the day and age).