### PR TITLE
[util] Disable direct buffer mapping for Red Faction

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -710,6 +710,11 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },
     }} },
+    /* Red Faction                               *
+     * Fixes crashing when starting a new game   */
+    { R"(\\RF\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Suggested by @Blisto91, confirmed to address the last remaining issue with Red Faction (fixes #62), namely the crashing on starting a new game.