### PR TITLE
[misc] Only request d3d8 & d3d9 logs in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ Name of the game, settings used etc.
 - GPU:
 - Driver:
 - Wine version: 
-- DXVK version: 
+- D8VK version: 
 
 ### Apitrace file(s)
 - Put a link here
@@ -26,6 +26,5 @@ Name of the game, settings used etc.
 For instructions on how to use apitrace, see: https://github.com/doitsujin/dxvk/wiki/Using-Apitrace
 
 ### Log files
+- d3d8.log:
 - d3d9.log:
-- d3d11.log:
-- dxgi.log:


### PR DESCRIPTION
Can't lie that this PR isn't mainly an attempt to make my own life easier when raising issues in bulk, but it should also make sense for others in general.