### PR TITLE
[d3d8] Validate depth stencil formats

### DIFF
--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -15,6 +15,17 @@ namespace dxvk {
     return isDXT(D3DFORMAT(fmt));
   }
 
+  inline constexpr bool isSupportedDepthStencilFormat(D3DFORMAT fmt) {
+    // native d3d8 doesn't support D3DFMT_D32, D3DFMT_D15S1 or D3DFMT_D24X4S4
+    return fmt == D3DFMT_D16_LOCKABLE
+        || fmt == D3DFMT_D16
+        //|| fmt == D3DFMT_D32
+        //|| fmt == D3DFMT_D15S1
+        //|| fmt == D3DFMT_D24X4S4
+        || fmt == D3DFMT_D24S8
+        || fmt == D3DFMT_D24X8;
+  }
+
   // Get bytes per pixel (or 4x4 block for DXT)
   inline constexpr UINT getFormatStride(D3DFORMAT fmt) {
     switch (fmt) {

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -5,6 +5,7 @@
 #include "d3d8_include.h"
 #include "d3d8_d3d9_util.h"
 #include "d3d8_options.h"
+#include "d3d8_format.h"
 #include "../d3d9/d3d9_bridge.h"
 
 //#include "../dxvk/dxvk_instance.h"
@@ -121,13 +122,16 @@ namespace dxvk {
         D3DFORMAT AdapterFormat,
         D3DFORMAT RenderTargetFormat,
         D3DFORMAT DepthStencilFormat) {
-      return m_d3d9ex->CheckDepthStencilMatch(
-        Adapter,
-        (d3d9::D3DDEVTYPE)DeviceType,
-        (d3d9::D3DFORMAT)AdapterFormat,
-        (d3d9::D3DFORMAT)RenderTargetFormat,
-        (d3d9::D3DFORMAT)DepthStencilFormat
-      );
+      if (isSupportedDepthStencilFormat(DepthStencilFormat))
+        return m_d3d9ex->CheckDepthStencilMatch(
+          Adapter,
+          (d3d9::D3DDEVTYPE)DeviceType,
+          (d3d9::D3DFORMAT)AdapterFormat,
+          (d3d9::D3DFORMAT)RenderTargetFormat,
+          (d3d9::D3DFORMAT)DepthStencilFormat
+        );
+
+      return D3DERR_NOTAVAILABLE;
     }
 
     HRESULT STDMETHODCALLTYPE GetDeviceCaps(


### PR DESCRIPTION
Fixes #87 , fixes #88  and fixes #118 (addressing the points highlighted therein). I'm not entirely sure if it breaks something or if we should rather app profile these formats rather than outright not supporting them, however this approach seems to be in line with both what native d3d8 and WineD3D are currently doing. Also not entirely sure if this is in any way relevant to d3d9, which is why I've kept everything in d3d8 code.