### PR TITLE
[d3d8] RefCount refactoring

### DIFF
--- a/src/d3d8/d3d8_blit.cpp
+++ b/src/d3d8/d3d8_blit.cpp
@@ -234,7 +234,7 @@ namespace dxvk {
         case D3DPOOL_SYSTEMMEM: {
 
           // RT (DEFAULT) -> SYSTEMMEM: Use GetRenderTargetData as fast path if possible
-          if ((srcDesc.Usage & D3DUSAGE_RENDERTARGET || m_renderTarget == src)) {
+          if ((srcDesc.Usage & D3DUSAGE_RENDERTARGET || m_renderTarget.ptr() == src.ptr())) {
 
             // GetRenderTargetData works if the formats and sizes match
             if (srcDesc.MultiSampleType == d3d9::D3DMULTISAMPLE_NONE

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -368,30 +368,76 @@ namespace dxvk {
 
       if (pRenderTarget != NULL) {
         D3D8Surface* surf = static_cast<D3D8Surface*>(pRenderTarget);
-        res = GetD3D9()->SetRenderTarget(0, surf->GetD3D9());
 
-        if (FAILED(res)) return res;
+        D3DSURFACE_DESC rtDesc;
+        surf->GetDesc(&rtDesc);
 
-        m_renderTarget = ref(surf);
+        if (unlikely(!(rtDesc.Usage & D3DUSAGE_RENDERTARGET)))
+          return D3DERR_INVALIDCALL;
+
+        if(likely(m_renderTarget.ptr() != surf)) {
+          res = GetD3D9()->SetRenderTarget(0, surf->GetD3D9());
+
+          if (FAILED(res)) return res;
+
+          D3D8Surface* pRenderTargetSwap = nullptr;
+          bool isRTSwap = m_renderTargetPrev.ptr() == surf;
+
+          if(unlikely(isRTSwap))
+            // keep a temporary ref on the prev RT to prevent its release
+            pRenderTargetSwap = m_renderTargetPrev.ref();
+
+          m_renderTargetPrev = m_renderTarget;
+          m_renderTarget = surf;
+
+          if(unlikely(isRTSwap && pRenderTargetSwap))
+            pRenderTargetSwap->Release();
+        }
       }
 
       // SetDepthStencilSurface is a separate call
       D3D8Surface* zStencil = static_cast<D3D8Surface*>(pNewZStencil);
-      res = GetD3D9()->SetDepthStencilSurface(D3D8Surface::GetD3D9Nullable(zStencil));
 
-      if (FAILED(res)) return res;
+      if(pNewZStencil != NULL) {
+        D3DSURFACE_DESC zsDesc;
+        zStencil->GetDesc(&zsDesc);
 
-      m_depthStencil = ref(zStencil);
-      return res;
+        if (unlikely(!(zsDesc.Usage & D3DUSAGE_DEPTHSTENCIL)))
+          return D3DERR_INVALIDCALL;
+      }
+
+      if(likely(m_depthStencil.ptr() != zStencil)) {
+        res = GetD3D9()->SetDepthStencilSurface(D3D8Surface::GetD3D9Nullable(zStencil));
+
+        if (FAILED(res)) return res;
+
+        D3D8Surface* pDepthStencilSwap = nullptr;
+        bool isDSSwap = m_depthStencilPrev.ptr() == zStencil;
+
+        if(unlikely(isDSSwap))
+          // keep a temporary ref on the prev DS to prevent its release
+          pDepthStencilSwap = m_depthStencilPrev.ref();
+
+        m_depthStencilPrev = m_depthStencil;
+        m_depthStencil = zStencil;
+
+        if(unlikely(isDSSwap && pDepthStencilSwap))
+          pDepthStencilSwap->Release();
+      }
+
+      return D3D_OK;
     }
 
     HRESULT STDMETHODCALLTYPE GetRenderTarget(IDirect3DSurface8** ppRenderTarget) {
+      InitReturnPtr(ppRenderTarget);
 
       if (unlikely(m_renderTarget == nullptr)) {
         Com<d3d9::IDirect3DSurface9> pRT9 = nullptr;
         HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9); // use RT index 0
 
-        m_renderTarget = ref(new D3D8Surface(this, std::move(pRT9)));
+        if(FAILED(res)) return res;
+
+        m_renderTarget = new D3D8Surface(this, std::move(pRT9));
 
         *ppRenderTarget = m_renderTarget.ref();
         return res;
@@ -402,12 +448,15 @@ namespace dxvk {
     }
 
     HRESULT STDMETHODCALLTYPE GetDepthStencilSurface(IDirect3DSurface8** ppZStencilSurface) {
+      InitReturnPtr(ppZStencilSurface);
       
       if (unlikely(m_depthStencil == nullptr)) {
         Com<d3d9::IDirect3DSurface9> pStencil9 = nullptr;
         HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
 
-        m_depthStencil = ref(new D3D8Surface(this, std::move(pStencil9)));
+        if(FAILED(res)) return res;
+
+        m_depthStencil = new D3D8Surface(this, std::move(pStencil9));
 
         *ppZStencilSurface = m_depthStencil.ref();
         return res;
@@ -834,7 +883,9 @@ namespace dxvk {
       }
       m_frontBuffer = nullptr;
       m_renderTarget = nullptr;
+      m_renderTargetPrev = nullptr;
       m_depthStencil = nullptr;
+      m_depthStencilPrev = nullptr;
     }
 
     friend d3d9::IDirect3DPixelShader9* getPixelShaderPtr(D3D8DeviceEx* device, DWORD Handle);
@@ -867,8 +918,10 @@ namespace dxvk {
     std::vector<Com<D3D8Surface, false>> m_backBuffers;
     Com<D3D8Surface>            m_frontBuffer;
 
-    Com<D3D8Surface>            m_renderTarget;
+    Com<D3D8Surface, false>     m_renderTarget;
+    Com<D3D8Surface, false>     m_renderTargetPrev;
     Com<D3D8Surface, false>     m_depthStencil;
+    Com<D3D8Surface, false>     m_depthStencilPrev;
 
     std::vector<D3D8VertexShaderInfo>           m_vertexShaders;
     std::vector<d3d9::IDirect3DPixelShader9*>   m_pixelShaders;

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -151,6 +151,7 @@ namespace dxvk {
             UINT iBackBuffer,
             D3DBACKBUFFER_TYPE Type,
             IDirect3DSurface8** ppBackBuffer) {
+      InitReturnPtr(ppBackBuffer);
       
       if (iBackBuffer >= m_backBuffers.size() || m_backBuffers[iBackBuffer] == nullptr) {
         Com<d3d9::IDirect3DSurface9> pSurface9;
@@ -158,7 +159,7 @@ namespace dxvk {
 
         if (FAILED(res)) return res;
         
-        m_backBuffers[iBackBuffer] = ref(new D3D8Surface(this, std::move(pSurface9)));
+        m_backBuffers[iBackBuffer] = new D3D8Surface(this, std::move(pSurface9));
         *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
 
         return res;
@@ -821,8 +822,11 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE GetIndices(
             IDirect3DIndexBuffer8** ppIndexData,
             UINT* pBaseVertexIndex) {
+      InitReturnPtr(ppIndexData);
+
       *ppIndexData      = m_indices.ptr();
       *pBaseVertexIndex = m_baseVertexIndex;
+
       return D3D_OK;
     }
 
@@ -881,7 +885,6 @@ namespace dxvk {
       for (UINT i = 0; i < m_presentParams.BackBufferCount; i++) {
         m_backBuffers.push_back(nullptr);
       }
-      m_frontBuffer = nullptr;
       m_renderTarget = nullptr;
       m_renderTargetPrev = nullptr;
       m_depthStencil = nullptr;
@@ -903,20 +906,19 @@ namespace dxvk {
     D3D8StateBlock* m_recorder = nullptr;
 
     struct D3D8VBO {
-      Com<D3D8VertexBuffer>   buffer = nullptr;
-      UINT                    stride = 0;
+      Com<D3D8VertexBuffer, false>   buffer = nullptr;
+      UINT                           stride = 0;
     };
     
     // Remember to fill() these in the constructor!
     std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES>  m_textures;
     std::array<D3D8VBO, d8caps::MAX_STREAMS>                           m_streams;
 
-    Com<D3D8IndexBuffer>        m_indices;
-    INT                         m_baseVertexIndex = 0;
+    Com<D3D8IndexBuffer, false>        m_indices;
+    INT                                m_baseVertexIndex = 0;
 
     // TODO: Which of these should be a private ref
     std::vector<Com<D3D8Surface, false>> m_backBuffers;
-    Com<D3D8Surface>            m_frontBuffer;
 
     Com<D3D8Surface, false>     m_renderTarget;
     Com<D3D8Surface, false>     m_renderTargetPrev;

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -567,7 +567,10 @@ namespace dxvk {
 
       D3D8Texture2D* tex = static_cast<D3D8Texture2D*>(pTexture);
 
-      m_textures[Stage] = ref(tex);
+      if(unlikely(m_textures[Stage].ptr() == tex))
+        return D3D_OK;
+
+      m_textures[Stage] = tex;
 
       return GetD3D9()->SetTexture(Stage, D3D8Texture2D::GetD3D9Nullable(tex));
     }
@@ -854,7 +857,7 @@ namespace dxvk {
     };
     
     // Remember to fill() these in the constructor!
-    std::array<Com<IDirect3DBaseTexture8>, d8caps::MAX_TEXTURE_STAGES> m_textures;
+    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES>  m_textures;
     std::array<D3D8VBO, d8caps::MAX_STREAMS>                           m_streams;
 
     Com<D3D8IndexBuffer>        m_indices;

--- a/src/d3d8/d3d8_device_child.h
+++ b/src/d3d8/d3d8_device_child.h
@@ -32,6 +32,10 @@ namespace dxvk {
     }
     
     ULONG STDMETHODCALLTYPE Release() {
+      // ignore Release calls on objects with 0 refCount
+      if(unlikely(!this->m_refCount))
+        return this->m_refCount;
+
       uint32_t refCount = --this->m_refCount;
       if (unlikely(!refCount)) {
         auto* pDevice = GetDevice();

--- a/src/d3d8/d3d8_state_block.cpp
+++ b/src/d3d8/d3d8_state_block.cpp
@@ -9,8 +9,12 @@ HRESULT dxvk::D3D8StateBlock::Capture() {
   if (m_capture.ps) m_device->GetPixelShader(&m_pixelShader);
 
   for (DWORD stage = 0; stage < m_textures.size(); stage++)
-    if (m_capture.textures.get(stage))
+    if (m_capture.textures.get(stage)) {
       m_device->GetTexture(stage, &m_textures[stage]);
+      // we are adding a needless ref when calling GetTexture, so release it
+      if(m_textures[stage])
+        m_textures[stage]->Release();
+    }
 
   if (m_capture.indices) m_device->GetIndices(&m_indices, &m_baseVertexIndex);
 
@@ -32,7 +36,7 @@ HRESULT dxvk::D3D8StateBlock::Apply() {
 
   for (DWORD stage = 0; stage < m_textures.size(); stage++)
     if (m_capture.textures.get(stage))
-      m_device->SetTexture(stage, m_textures[stage] );
+      m_device->SetTexture(stage, m_textures[stage]);
 
   if (m_capture.indices) m_device->SetIndices(m_indices, m_baseVertexIndex);
 

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -103,7 +103,7 @@ namespace dxvk {
       return ptr;
     }
 
-    std::vector<Com<SubresourceType>> m_subresources;
+    std::vector<Com<SubresourceType, false>> m_subresources;
 
   };
 


### PR DESCRIPTION
Com objects already ref to the return pointer, so the current way of doing things will actually double refcount on certain calls, as can be seen in some traces. Doesn't fix any game per se as it stands and not sure if it will ultimately go anywhere, but some refcounts now appear to be more sane.

A good game to use for chasing the refs and comparing against how WineD3D refcounts is #92 . It in particular will crash due to an invalid ref count on an IDirect3DTexture8 object, but it also creates and releases a whole bunch of other things on startup before crashing which have invalid ref counts (some of which are addressed by this PR).

Next steps, based on the trace I'm looking at at least, would indicate:
- render target references need to be made private, however that blows up subresouces spectacularly, and m_container references no longer work for some reason (haven't figured it out yet)
- there is one more extra refcount on the parent IDirect3DTexture8 object which prevents its release, even if render targets are made private (this kinds of works if commenting out subresource refcounts to m_container in AddRef() and Release() ). I haven't yet found its annoyingly camouflaged hiding place.

Edit: Fixes #57, fixes #78, fixes #90, fixes #92, fixes #97, fixes #123.