### PR TITLE
[util] Enable apitraceMode for Motor City Online

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -750,6 +750,10 @@ namespace dxvk {
     { R"(\\RF\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Motor City Online                         */
+    { R"(\\MCity_d\.exe$)", {{
+      { "d3d9.apitraceMode",                "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Vastly improves in-game performance, since Motor City Online appears to rely heavily on vertex/index buffers. My fps has gone up from about 10-15-ish on low to 30-40-ish maxed out. Fixes #121 - the game already works with d8vk in Wine, no other hacks required beyond those described initially in the issue report, which are game-specific hacks.

P.S.: I was actually dumb and forgot the apitrace dll in my game folder. Once that was removed this PR yields 50+ fps constantly, most of the time being capped at 60.