### PR TITLE
[d3d8] Uncomment forwarding calls to SetCursorPosition

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -103,13 +103,13 @@ namespace dxvk {
 
     void    STDMETHODCALLTYPE SetCursorPosition(UINT XScreenSpace, UINT YScreenSpace, DWORD Flags) {
       // TODO: do we need to convert from screenspace?
-      //GetD3D9()->SetCursorPosition(XScreenSpace, YScreenSpace, Flags);
+      GetD3D9()->SetCursorPosition(XScreenSpace, YScreenSpace, Flags);
     }
 
     // Microsoft d3d8.h in the DirectX 9 SDK uses a different function signature...
     void    STDMETHODCALLTYPE SetCursorPosition(int X, int Y, DWORD Flags) {
       // TODO: do we need to convert from screenspace?
-      //GetD3D9()->SetCursorPosition(X, Y, Flags);
+      GetD3D9()->SetCursorPosition(X, Y, Flags);
     }
 
     BOOL    STDMETHODCALLTYPE ShowCursor(BOOL bShow) { return GetD3D9()->ShowCursor(bShow); }


### PR DESCRIPTION
Not sure why these were even commented in the first place?

Restaurant Empire actually uses SetCursorPosition throughout the game. Perhaps some conversion is needed to set the initial position (not really sure here), but in terms of actual functionality it seems to be working just fine as is, with simple forwarding to d3d9.

With them commented the game is unplayable, as one would expect from a game that relies solely on cursor interactions.

Edit: Fixes #128.