### PR TITLE
[util] Add a memory limit for Supreme Ruler 2020

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -750,6 +750,12 @@ namespace dxvk {
     { R"(\\RF\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Supreme Ruler 2020 Gold                   *
+     * Fixes crashing when switching zoom levels */
+    { R"(\\SupremeRuler2020GC\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "1024" },
+    }} },
   }};
 
 


### PR DESCRIPTION
The game will frequently crash when switching between zoom levels otherwise. Partially addresses #130, and in conjunction with the game's builtin workaround for flickering issues gets the game to a playable state with d8vk (although due to the insane number of draw calls, performance will be terrible).