### PR TITLE
[util] Disable direct buffer mapping for Commandos 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -750,6 +750,13 @@ namespace dxvk {
     { R"(\\RF\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Commandos 3                               *
+     * The game doesn't use NOOVERWRITE properly *
+     * and reads from actively modified buffers, *
+     * which causes graphical glitches at times  */
+    { R"(\\Commandos3\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #107. Should really be credited to @K0bin and @Blisto91, who figured out what was going on for https://github.com/doitsujin/dxvk/issues/3336. It reminded me of something I had seen before in a trace, and, lo and behold, it was indeed what this game was doing.