### PR TITLE
[util] Add a buffer placement workaround for various games

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -7,6 +7,7 @@
 
 #include "d3d8_include.h"
 #include "d3d8_format.h"
+#include "d3d8_options.h"
 
 #include <utility>
 
@@ -14,7 +15,7 @@ namespace dxvk {
 
 
   // Remap certain vertex and index buffers to different pools.
-  inline std::pair<DWORD, d3d9::D3DPOOL> ChooseBufferPool(DWORD Usage, D3DPOOL Pool8) {
+  inline std::pair<DWORD, d3d9::D3DPOOL> ChooseBufferPool(DWORD Usage, D3DPOOL Pool8, const D3D8Options& options) {
 
     d3d9::D3DPOOL Pool = d3d9::D3DPOOL(Pool8);
 
@@ -26,7 +27,7 @@ namespace dxvk {
     //   due to differences in the behavior of NOOVERWRITE that will
     //   make apps write over in-use buffers that they expect to wait for.
     // - D3D9DeviceEx::LockBuffer will ignored DISCARD and NOOVERWRITE for us
-    if (Pool8 == D3DPOOL_DEFAULT) {
+    if (Pool8 == D3DPOOL_DEFAULT && options.managedBufferPlacement) {
       Pool = d3d9::D3DPOOL_MANAGED;
       Usage &= ~D3DUSAGE_DYNAMIC;
     }

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -265,7 +265,7 @@ namespace dxvk {
       InitReturnPtr(ppVertexBuffer);
       Com<d3d9::IDirect3DVertexBuffer9> pVertexBuffer9 = nullptr;
 
-      auto [usage, realPool] = ChooseBufferPool(Usage, Pool);
+      auto [usage, realPool] = ChooseBufferPool(Usage, Pool, m_d3d8Options);
       HRESULT res = GetD3D9()->CreateVertexBuffer(Length, usage, FVF, realPool, &pVertexBuffer9, NULL);
 
       if (!FAILED(res))
@@ -283,7 +283,7 @@ namespace dxvk {
       InitReturnPtr(ppIndexBuffer);
       Com<d3d9::IDirect3DIndexBuffer9> pIndexBuffer9 = nullptr;
       
-      auto [usage, realPool] = ChooseBufferPool(Usage, Pool);
+      auto [usage, realPool] = ChooseBufferPool(Usage, Pool, m_d3d8Options);
       HRESULT res = GetD3D9()->CreateIndexBuffer(Length, usage, d3d9::D3DFORMAT(Format), realPool, &pIndexBuffer9, NULL);
       
       if (!FAILED(res))

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -11,9 +11,14 @@ namespace dxvk {
     /// Also emulates hardware shadow filtering using a bilinear 2x2 PCF.
     bool useShadowBuffers = false;
 
+    /// Remap DEFAULT pool vertex buffers to MANAGED in order to optimize
+    /// performance in cases where applications perform read backs
+    bool managedBufferPlacement = true;
+
     D3D8Options() {}
     D3D8Options(const Config& config) {
       useShadowBuffers = config.getOption("d3d8.useShadowBuffers", useShadowBuffers);
+      managedBufferPlacement = config.getOption("d3d8.managedBufferPlacement", managedBufferPlacement);
     }
 
   };

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -762,6 +762,10 @@ namespace dxvk {
       { "d3d9.apitraceMode",                "True" },
       { "d3d8.managedBufferPlacement",     "False" },
     }} },
+    /* Brigade E5: New Jagged Union              */
+    { R"(\\E5\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
   }};
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -760,6 +760,7 @@ namespace dxvk {
     /* Motor City Online                         */
     { R"(\\MCity_d\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
+      { "d3d8.managedBufferPlacement",     "False" },
     }} },
   }};
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -766,6 +766,10 @@ namespace dxvk {
     { R"(\\E5\.exe$)", {{
       { "d3d8.managedBufferPlacement",     "False" },
     }} },
+    /* Railroad Tycoon 3                         */
+    { R"(\\RT3\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Restores slower but proper "quad" rendering behavior in Motor City Online, by mapping vertex/index buffers in D3DPOOL_DEFAULT, as the game insists. This fixes a regression introduced by 3b029ec.

Hopefully this will be the only game that will ever need this config option. Everything else I've tested so far doesn't seem to mind the new MANAGED status quo.