### PR TITLE
[util] Remove superfluous allowDirectBufferMapping workarounds

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -745,18 +745,6 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },
     }} },
-    /* Red Faction                               *
-     * Fixes crashing when starting a new game   */
-    { R"(\\RF\.exe$)", {{
-      { "d3d9.allowDirectBufferMapping",   "False" },
-    }} },
-    /* Commandos 3                               *
-     * The game doesn't use NOOVERWRITE properly *
-     * and reads from actively modified buffers, *
-     * which causes graphical glitches at times  */
-    { R"(\\Commandos3\.exe$)", {{
-      { "d3d9.allowDirectBufferMapping",   "False" },
-    }} },
     /* Motor City Online                         */
     { R"(\\MCity_d\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },


### PR DESCRIPTION
These are no longer needed now, since we are storing DEFAULT buffers to MANAGED. I've tested both games on main without the workarounds and they behave correctly.