### PR TITLE
[d3d8] Release refs on previous render targets and depth stencils

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -390,6 +390,8 @@ namespace dxvk {
             m_renderTarget = surf;
           }
           m_renderTarget.ref();
+          if(m_renderTargetPrev.ptr() != nullptr)
+            m_renderTargetPrev->Release();
         }
       }
 
@@ -408,6 +410,8 @@ namespace dxvk {
           m_depthStencil = zStencil;
         }
         m_depthStencil.ref();
+        if(m_depthStencilPrev.ptr() != nullptr)
+          m_depthStencilPrev->Release();
       }
 
       return D3D_OK;


### PR DESCRIPTION
As you are aware, the added .ref()s in 08e183f regress almost every game that had issues with refcounts and was fixed by #122, namely the 2 BloodRaynes, Blowout and Firestarter.

The D3D8 docs say the following with regards to IDirect3DDevice8::SetRenderTarget:

`The device will call AddRef on each non-NULL surface passed to SetRenderTarget. After that the device calls Release on the previously set color buffer. `

Doing exactly that fixes all the above problematic games again, so seems to be a good avenue to explore. I am hoping it will also address the regression with MGS2 in way that doesn't crash the game again, but I don't have the game so can't confirm.