### PR TITLE
[util] Add workarounds for SR2010 and Zwei: The Ilvard Insurrection

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -771,6 +771,18 @@ namespace dxvk {
     { R"(\\Pure Pinball 2.0 REDUX\.exe$)", {{
       { "d3d8.forceVsDecl",                 "0:2,4:2,7:4,9:1,8:1" },
     }} },
+    /* Supreme Ruler 2010                        *
+     * Needs the same workaround as SR2020 to    *
+     * fix flickering on text + no explicit      *
+     * front buffer to fix flickering in general */
+    { R"(\\SupremeRuler\.exe$)", {{
+      { "d3d9.noExplicitFrontBuffer",       "True" },
+      { "d3d8.managedBufferPlacement",     "21600" },
+    }} },
+    /* Zwei: The Ilvard Insurrection             */
+    { R"(\\ZWEI2P\.exe$)", {{
+      { "d3d9.noExplicitFrontBuffer",       "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #106 and Zwei by using `d3d9.noExplicitFrontBuffer = True`, at least until upstream comes up with a better option. We can re-evaluate/remove the workarounds when that happens.

Supreme Ruler 2010 also turned out to need the same managed buffer placement workaround as SR2020 now, to no one's surprise.