### PR TITLE
[util] Add workarounds for NFS 3 and 4

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -620,10 +620,6 @@ namespace dxvk {
     { R"(\\bionic_commando\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
-    /* Need For Speed 3 modern patch            */
-    { R"(\\nfs3\.exe$)", {{
-      { "d3d9.enableDialogMode",          "True" },
-    }} },
     /* Beyond Good And Evil                     *
      * UI breaks at high fps                     */
     { R"(\\BGE\.exe$)", {{
@@ -782,6 +778,23 @@ namespace dxvk {
     /* Zwei: The Ilvard Insurrection             */
     { R"(\\ZWEI2P\.exe$)", {{
       { "d3d9.noExplicitFrontBuffer",       "True" },
+    }} },
+    /* Need for Speed III: Hot Pursuit           *
+       (with the "Modern Patch")                 */
+    { R"(\\nfs3\.exe$)", {{
+      { "d3d9.enableDialogMode",            "True" },
+      { "d3d9.apitraceMode",                "True" },
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* Need for Speed: High Stakes / Road         *
+       Challenge (with the "Modern Patch") -      *
+       Won't actually render anything in game     *
+       without a memory limit in place            */
+    { R"(\\nfs4\.exe$)", {{
+      { "d3d9.enableDialogMode",            "True" },
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",           "256" },
+      { "d3d8.managedBufferPlacement",     "False" },
     }} },
   }};
 


### PR DESCRIPTION
Both Need for Speed 3 and 4 can be played on modern systems using a "modern patch", which provides a d3d8 renderer inspired by the one available in MCO. Therefore, to no one's surprise, they are mostly affected by the same problems, namely:

- NFS 3:
   - half-quads without MANAGED placement disabled
   - poor performance without apitraceMode enabled

- NFS 4:
   - half-quads without MANAGED placement disabled
   - rendering issues without capped VRAM (it will only render the UI in-game without a limit in place)
   - strangely, it appears unaffected by apitraceMode and performance is fine even without it

I expect both games will benefit from the batch renderer when it is ready, but for now should be more than playable with the above.

On a side-note, support for these games is bad in WineD3D. The d3d6 renderer crashes when it reaches the main menu. The d3d7 renderer doesn't crash but is a complete slideshow (I'm talking fractional fps here). d3d8 has the usual half-quads and broken geometry. nGlide only renders a black screen. dgVoodoo works but with constant hitching. And last, but not least, software mode is just... well, as bad looking as you'd expect. So really d3d8 with d8vk is the only way I've been able to play these games without issues in Wine (with the above config options in place) :+1: .
