### PR TITLE
[util] Remove the noExplicitFrontBuffer workarounds (fixed upstream)

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -851,15 +851,9 @@ namespace dxvk {
     }} },
     /* Supreme Ruler 2010                        *
      * Needs the same workaround as SR2020 to    *
-     * fix flickering on text + no explicit      *
-     * front buffer to fix flickering in general */
+     * fix flickering on UI text                 */
     { R"(\\SupremeRuler\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
       { "d3d8.managedBufferPlacement",     "21600" },
-    }} },
-    /* Zwei: The Ilvard Insurrection             */
-    { R"(\\ZWEI2P\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
     }} },
     /* Need for Speed III: Hot Pursuit           *
        (with the "Modern Patch")                 */


### PR DESCRIPTION
Well, these were probably the shortest lived changes ever...

The underlying issue was fixed upstream and the noExplicitFrontBuffer workaround was removed. Please merge before a rebase (or remember that we need to remove these on the next rebase).