### PR TITLE
[util] d8vk 1.0 regression testing workarounds

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -834,6 +834,7 @@ namespace dxvk {
     }} },
     /* Railroad Tycoon 3                         */
     { R"(\\RT3\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.managedBufferPlacement",     "False" },
     }} },
     /* Supreme Ruler 2020: Gold                  *
@@ -892,6 +893,33 @@ namespace dxvk {
     /* Scrapland (Remastered)                   */
     { R"(\\Scrap\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
+    /* Port Royale 2                              *
+     * UI rendering issues with managed buffers   */
+    { R"(\\PR2\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* Sherlock Holmes: The Secret of the Silver  *
+     * Earring                                    */
+    { R"(\\Sherlock Holmes.*(SSE|Silver Earring)\\game\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* The Guild Gold Edition (Europa 1400)       *
+     * UI rendering issues with managed buffers   */
+    { R"(\\Europa1400Gold_TL\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* Icoming Forces                             */
+    { R"(\\forces\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* Chaser                                     */
+    { R"(\\Chaser\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
+    /* Rise of Nations Gold                       */
+    { R"(\\(nations|patriots)\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
     }} },
   }};
 


### PR DESCRIPTION
I've uncovered the following issues (mostly buffer placement related), during d8vk 1.0 regression testing done on 120+ d3d8 games:

- Chaser - performance regression with managed buffer placement
- IGI 2: Covert Strike - typo fix on existing workaround
- Incoming Forces - broken skybox (the main issue with the game, still present, may be msvcrt sse2 related)
- Port Royale 2 - broken UI menus with managed buffer placement
- Railroad Tycoon 3 - broken physics on various graphical elements without a framerate cap (60 should be fine for a tycoon game)
- Sherlock Holmes: The Secret of the Silver Earring - major performance regression with managed buffer placement
- The Guild Gold (Europa 1400) - broken UI menus with managed buffer placement
- Rise of Nations Gold - broken terrain and shadow rendering with managed buffer placement

This PR addresses all of the above.