### PR TITLE
[util] Rename apitraceMode config options (inline with upstream)

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -824,7 +824,7 @@ namespace dxvk {
     }} },
     /* Motor City Online                         */
     { R"(\\MCity_d\.exe$)", {{
-      { "d3d9.apitraceMode",                "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d8.managedBufferPlacement",     "False" },
       { "d3d8.batching",                    "True" },
     }} },
@@ -865,7 +865,7 @@ namespace dxvk {
        (with the "Modern Patch")                 */
     { R"(\\nfs3\.exe$)", {{
       { "d3d9.enableDialogMode",            "True" },
-      { "d3d9.apitraceMode",                "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d8.managedBufferPlacement",     "False" },
       { "d3d8.batching",                    "True" },
     }} },
@@ -875,6 +875,7 @@ namespace dxvk {
        without a memory limit in place            */
     { R"(\\nfs4\.exe$)", {{
       { "d3d9.enableDialogMode",            "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",           "256" },
       { "d3d8.managedBufferPlacement",     "False" },
@@ -882,8 +883,8 @@ namespace dxvk {
     }} },
     /* Project I.G.I. 2: Covert Strike            */
     { R"(\\igi2\.exe$)", {{
-      { "d3d9.managedBufferPlacement",     "False" },
-      { "d3d9.apitraceMode",                "True" },
+      { "d3d8.managedBufferPlacement",     "False" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Treasure Planet: Battle at Procyon        *
      * Declares v5 as color but shader uses v6   */


### PR DESCRIPTION
Another thing to do or keep in mind before/after the next rebase.

See: https://github.com/doitsujin/dxvk/commit/5fd025c5139b208d4bfd4c04a58d7fcbb2a6ef9a

I also took the liberty to add apitraceMode/cachedDynamicBuffers to NFS4, since people can use/are using the renderer from the NFS3 modern patch with NFS4 as well, since the one provided with NFS3 is more recent (the games are compatible in that regard, looks like).