### PR TITLE
[d3d8] Forward calls to TestCooperativeLevel

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -136,8 +136,8 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D8Device::TestCooperativeLevel() {
-    // Equivelant of D3D11/DXGI present tests. We can always present.
-    return D3D_OK;
+    // Equivalent of D3D11/DXGI present tests.
+    return GetD3D9()->TestCooperativeLevel();
   }
 
 


### PR DESCRIPTION
Closes #168 (hopefully should be enough, I still need to test it). Should ensure proper DEVICENOTRESET behavior in d3d8 as well. For more details, please see: https://github.com/doitsujin/dxvk/pull/3486 . I have a test in place that has confirmed WineD3D and native AMD enforce the behavior in D3D8, and in this regard the specs are the same anyway.