### PR TITLE
[d3d8] Ensure all references are cleared before d3d9 device reset

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -52,6 +52,7 @@ namespace dxvk {
     }
 
     m_bridge->SetAPIName("D3D8");
+    m_bridge->SetD3D8CompatibilityMode(true);
 
     ResetState();
     RecreateBackBuffersAndAutoDepthStencil();

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -53,10 +53,8 @@ namespace dxvk {
 
     m_bridge->SetAPIName("D3D8");
 
-    m_textures.fill(nullptr);
-    m_streams.fill(D3D8VBO());
-
     ResetState();
+    RecreateBackBuffersAndAutoDepthStencil();
     
     if (m_d3d8Options.batching)
       m_batcher = new D3D8Batcher(this, GetD3D9());
@@ -214,14 +212,16 @@ namespace dxvk {
     // Resetting implicitly ends scenes started by BeginScene
     GetD3D9()->EndScene();
 
+    m_presentParams = *pPresentationParameters;
+    ResetState();
+
     d3d9::D3DPRESENT_PARAMETERS params = ConvertPresentParameters9(pPresentationParameters);
     HRESULT res = GetD3D9()->Reset(&params);
 
     if (FAILED(res))
       return res;
 
-    m_presentParams = *pPresentationParameters;
-    ResetState();
+    RecreateBackBuffersAndAutoDepthStencil();
 
     return res;
   }
@@ -970,6 +970,7 @@ namespace dxvk {
 
     D3D8StateBlock* block = reinterpret_cast<D3D8StateBlock*>(Token);
     m_stateBlocks.erase(block);
+    delete block;
 
     return D3D_OK;
   }

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -385,13 +385,17 @@ namespace dxvk {
 
       m_backBuffers.clear();
       m_backBuffers.resize(m_presentParams.BackBufferCount);
+      
+      m_autoDepthStencil = nullptr;
+    }
+
+    inline void RecreateBackBuffersAndAutoDepthStencil() {
       for (UINT i = 0; i < m_presentParams.BackBufferCount; i++) {
         Com<d3d9::IDirect3DSurface9> pSurface9;
         GetD3D9()->GetBackBuffer(0, i, d3d9::D3DBACKBUFFER_TYPE_MONO, &pSurface9);
         m_backBuffers[i] = new D3D8Surface(this, std::move(pSurface9));
       }
-      
-      m_autoDepthStencil = nullptr;
+
       Com<d3d9::IDirect3DSurface9> pStencil9 = nullptr;
       GetD3D9()->GetDepthStencilSurface(&pStencil9);
       m_autoDepthStencil = new D3D8Surface(this, std::move(pStencil9));

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -8,6 +8,8 @@ namespace dxvk {
       d3d9::D3DSURFACE_DESC desc;
       GetD3D9()->GetDesc(&desc);
 
+      // NOTE: This adds a D3DPOOL_DEFAULT resource to the
+      // device, which counts as losable during device reset
       Com<d3d9::IDirect3DSurface9> image = nullptr;
       HRESULT res = GetParent()->GetD3D9()->CreateRenderTarget(
         desc.Width, desc.Height, desc.Format,
@@ -19,7 +21,6 @@ namespace dxvk {
       if (FAILED(res))
         throw new DxvkError("D3D8: Failed to create blit image");
       
-      image.ref();
       return image;
     }
 }


### PR DESCRIPTION
Now that we've imported the new D3D9 device reset validations we also need ensure that:

- We clear all d3d8 cached references before calling d3d9 device reset

- We regenerate/rebind the backbuffers and autoDS after the d3d9 device reset succeeds

- We actually free state blocks on calls to DeleteStateBlock() 

Otherwise some d3d8 games will livelock and crash, complaining they can't reset the device with bound resources (it was the default render target, depth stencil and state blocks that were bound from our end). 

Fixes #174, fixes #175, partially addresses #59 (fixes the startup crash, as that seems to have been state block related).