### PR TITLE
[util] Add a workaround for Soldiers: Heroes of WWII

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -921,6 +921,12 @@ namespace dxvk {
     { R"(\\(nations|patriots)\.exe$)", {{
       { "d3d8.managedBufferPlacement",     "False" },
     }} },
+    /* Soldiers: Heroes Of World War II           *
+     * Fills up all available memory and hangs    *
+     * while loading the main menu otherwise      */
+    { R"(\\Soldiers\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
It used to work without tinkering before, however it may have been an unintended consequence of us not properly freeing state blocks. The game is all manners of broken anyway (unrelated to d3d) and was unplayable on Wine until recently, so the fact it needs this is not all that surprising.