### PR TITLE
[util] Remove workaround for D&D: ToEE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -886,10 +886,6 @@ namespace dxvk {
     { R"(\\TP_Win32\.exe$)", {{
       { "d3d8.forceVsDecl",      "0:2,3:2,6:4,7:1" },
     }} },
-    /* D&D - The Temple Of Elemental Evil          */
-    { R"(\\ToEE(a)?\.exe$)", {{
-      { "d3d9.allowDiscard",                "False" },
-    }} },
     /* Scrapland (Remastered)                   */
     { R"(\\Scrap\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },


### PR DESCRIPTION
Just so we don't forget about this, since with d8vk it got moved to the d3d8 section. It's no longer needed as of https://github.com/doitsujin/dxvk/commit/9b877cf623d143ccea73016ce899384ce08977a0.