### PR TITLE
[util] Disable managedBufferPlacement for Enclave

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -921,6 +921,10 @@ namespace dxvk {
     { R"(\\(nations|patriots)\.exe$)", {{
       { "d3d8.managedBufferPlacement",     "False" },
     }} },
+    /* Enclave                                    */
+    { R"(\\Enclave\.exe$)", {{
+      { "d3d8.managedBufferPlacement",     "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Another rather serious performance regression due to our managedBufferPlacement workaround. They're really starting to pile up...