### PR TITLE
[d3d8 + util] Remove managedBufferPlacement and adjust config options

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -11,28 +11,6 @@
 
 namespace dxvk {
 
-
-  // Remap certain vertex and index buffers to different pools.
-  inline std::pair<DWORD, d3d9::D3DPOOL> ChooseBufferPool(DWORD Usage, D3DPOOL Pool8, UINT Length, const D3D8Options& options) {
-
-    d3d9::D3DPOOL Pool = d3d9::D3DPOOL(Pool8);
-
-    // TODO: Optimize carefully which buffers go in which pools.
-    // - WRITEONLY DYNAMIC buffers might get performance gains in DEFAULT if not misused
-
-    // Remap DEFAULT pool vertex buffers to MANAGED.
-    // - This avoids direct buffer mapping which can cause apps to misbehave
-    //   due to differences in the behavior of NOOVERWRITE that will
-    //   make apps write over in-use buffers that they expect to wait for.
-    // - D3D9DeviceEx::LockBuffer will ignored DISCARD and NOOVERWRITE for us
-    if (Pool8 == D3DPOOL_DEFAULT && Length >= options.managedBufferPlacement) {
-      Pool = d3d9::D3DPOOL_MANAGED;
-      Usage &= ~D3DUSAGE_DYNAMIC;
-    }
-
-    return {Usage, Pool};
-  }
-
   // (8<-9) D3DCAPSX: Writes to D3DCAPS8 from D3DCAPS9
   inline void ConvertCaps8(const d3d9::D3DCAPS9& caps9, D3DCAPS8* pCaps8) {
 

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -362,8 +362,7 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DVertexBuffer9> pVertexBuffer9 = nullptr;
 
-    auto [usage, realPool] = ChooseBufferPool(Usage, Pool, Length, m_d3d8Options);
-    HRESULT res = GetD3D9()->CreateVertexBuffer(Length, usage, FVF, realPool, &pVertexBuffer9, NULL);
+    HRESULT res = GetD3D9()->CreateVertexBuffer(Length, Usage, FVF, d3d9::D3DPOOL(Pool), &pVertexBuffer9, NULL);
 
     if (!FAILED(res))
       *ppVertexBuffer = ref(new D3D8VertexBuffer(this, std::move(pVertexBuffer9), Pool, Usage));
@@ -380,13 +379,12 @@ namespace dxvk {
     InitReturnPtr(ppIndexBuffer);
     Com<d3d9::IDirect3DIndexBuffer9> pIndexBuffer9 = nullptr;
     
-    auto [usage, realPool] = ChooseBufferPool(Usage, Pool, Length, m_d3d8Options);
-    HRESULT res = GetD3D9()->CreateIndexBuffer(Length, usage, d3d9::D3DFORMAT(Format), realPool, &pIndexBuffer9, NULL);
+    HRESULT res = GetD3D9()->CreateIndexBuffer(Length, Usage, d3d9::D3DFORMAT(Format), d3d9::D3DPOOL(Pool), &pIndexBuffer9, NULL);
     
     if (!FAILED(res))
       *ppIndexBuffer = ref(new D3D8IndexBuffer(this, std::move(pIndexBuffer9), Pool, Usage));
+    
     return res;
-
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateRenderTarget(

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -7,13 +7,6 @@
 namespace dxvk {
   struct D3D8Options {
 
-    /// Remap DEFAULT pool vertex and index buffers above this size to the MANAGED pool
-    /// to improve performance by avoiding waiting for games that frequently lock (large) buffers.
-    ///
-    /// This implicitly disables direct buffer mapping. Some applications may need this option
-    /// disabled for certain (smaller) buffers to keep from overwriting in-use buffer regions.
-    uint32_t managedBufferPlacement = 0;
-
     /// Some games rely on undefined behavior by using undeclared vertex shader inputs.
     /// The simplest way to fix them is to simply modify their vertex shader decl.
     /// 
@@ -30,8 +23,6 @@ namespace dxvk {
 
     D3D8Options() {}
     D3D8Options(const Config& config) {
-      int32_t minManagedSize  = config.getOption<int32_t>    ("d3d8.managedBufferPlacement", managedBufferPlacement);
-      managedBufferPlacement  = config.getOption<bool>       ("d3d8.managedBufferPlacement", true) ? minManagedSize : UINT32_MAX;
       auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",  "");
       batching                = config.getOption<bool>       ("d3d8.batching",               batching);
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1012,6 +1012,18 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },
     }} },
+    /* Red Faction                               *
+     * Fixes crashing when starting a new game   */
+    { R"(\\RF\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
+    /* Commandos 3                               *
+     * The game doesn't use NOOVERWRITE properly *
+     * and reads from actively modified buffers, *
+     * which causes graphical glitches at times  */
+    { R"(\\Commandos3\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
     /* Motor City Online                         */
     { R"(\\MCity_d\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
@@ -1078,6 +1090,12 @@ namespace dxvk {
     /* Alexander                                  */
     { R"(\\Alexander\\Data\\engine\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
+    }} },
+    /* 3DMark2001 (SE)                            *
+     * Fixes a drastic performance drop in the    *
+     * "Car Chase - High Detail" benchmark        */
+    { R"(\\3DMark2001(SE)?\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
   }};
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1118,6 +1118,15 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "512"  },
     }} },
+    /* Cossacks II: Napoleonic Wars &             *
+     * Battle for Europe                          */
+    { R"(\\Cossacks II.*\\engine\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
+    /* Alexander                                  */
+    { R"(\\Alexander\\Data\\engine\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
   }};
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1058,6 +1058,10 @@ namespace dxvk {
       { "d3d9.maxAvailableMemory",           "256" },
       { "d3d8.batching",                    "True" },
     }} },
+    /* Need for Speed: Hot Pursuit 2              */
+    { R"(\\NFSHP2\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
     /* Project I.G.I. 2: Covert Strike            */
     { R"(\\igi2\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
@@ -1096,6 +1100,14 @@ namespace dxvk {
      * "Car Chase - High Detail" benchmark        */
     { R"(\\3DMark2001(SE)?\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
+    /* Delta Force: Black Hawk Down               */
+    { R"(\\dfbhd\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
+    /* X2: The Threat                             */
+    { R"(\\X2\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
   }};
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1015,23 +1015,11 @@ namespace dxvk {
     /* Motor City Online                         */
     { R"(\\MCity_d\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
-      { "d3d8.managedBufferPlacement",     "False" },
       { "d3d8.batching",                    "True" },
-    }} },
-    /* Brigade E5: New Jagged Union              */
-    { R"(\\E5\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
     }} },
     /* Railroad Tycoon 3                         */
     { R"(\\RT3\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* Supreme Ruler 2020: Gold                  *
-     * Only put the large main vertex buffer in  *
-     * MANAGED to fix flickering on text and UI. */
-    { R"(\\SupremeRuler2020GC\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "21600" },
     }} },
     /* Pure Pinball 2.0 REDUX                    *
      * This game reads from undeclared vs inputs *
@@ -1040,18 +1028,11 @@ namespace dxvk {
     { R"(\\Pure Pinball 2\.0 REDUX\.exe$)", {{
       { "d3d8.forceVsDecl",  "0:2,4:2,7:4,9:1,8:1" },
     }} },
-    /* Supreme Ruler 2010                        *
-     * Needs the same workaround as SR2020 to    *
-     * fix flickering on UI text                 */
-    { R"(\\SupremeRuler\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "21600" },
-    }} },
     /* Need for Speed III: Hot Pursuit           *
        (with the "Modern Patch")                 */
     { R"(\\nfs3\.exe$)", {{
       { "d3d9.enableDialogMode",            "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
-      { "d3d8.managedBufferPlacement",     "False" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: High Stakes / Road         *
@@ -1063,12 +1044,10 @@ namespace dxvk {
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",           "256" },
-      { "d3d8.managedBufferPlacement",     "False" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Project I.G.I. 2: Covert Strike            */
     { R"(\\igi2\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Treasure Planet: Battle at Procyon        *
@@ -1079,33 +1058,6 @@ namespace dxvk {
     /* Scrapland (Remastered)                   */
     { R"(\\Scrap\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
-    }} },
-    /* Port Royale 2                              *
-     * UI rendering issues with managed buffers   */
-    { R"(\\PR2\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* Sherlock Holmes: The Secret of the Silver  *
-     * Earring                                    */
-    { R"(\\Sherlock Holmes.*(SSE|Silver Earring)\\game\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* The Guild Gold Edition (Europa 1400)       *
-     * UI rendering issues with managed buffers   */
-    { R"(\\Europa1400Gold_TL\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* Icoming Forces                             */
-    { R"(\\forces\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* Chaser                                     */
-    { R"(\\Chaser\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
-    }} },
-    /* Rise of Nations Gold                       */
-    { R"(\\(nations|patriots)\.exe$)", {{
-      { "d3d8.managedBufferPlacement",     "False" },
     }} },
     /* V-Rally 3                                  */
     { R"(\\VRally3(Demo)?\.exe$)", {{

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1076,10 +1076,6 @@ namespace dxvk {
     { R"(\\TP_Win32\.exe$)", {{
       { "d3d8.forceVsDecl",      "0:2,3:2,6:4,7:1" },
     }} },
-    /* D&D - The Temple Of Elemental Evil          */
-    { R"(\\ToEE(a)?\.exe$)", {{
-      { "d3d9.allowDiscard",                "False" },
-    }} },
     /* Scrapland (Remastered)                   */
     { R"(\\Scrap\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1111,6 +1111,13 @@ namespace dxvk {
     { R"(\\VRally3(Demo)?\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
     }} },
+    /* Soldiers: Heroes Of World War II           *
+     * Fills up all available memory and hangs    *
+     * while loading the main menu otherwise      */
+    { R"(\\Soldiers\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "512"  },
+    }} },
   }};
 
 


### PR DESCRIPTION
Includes #176 and #186. Fixes #198, fixes #154.

As mentioned in the issue, the main culprit and reason behind us going with managedBufferPlacement in the first place was 3DMark2001 SE, which was sort of a red herring because of my inaccurate testing (sorry for that, btw).

Since it no longer helps games such as Supreme Ruler 2010 / 2020, there's really no reason to keep it around at this point. Batching does look promising, however, to handle the jank these games throw at us, it just needs a bit more work, since it was never intended for these games in particular (it does fix the text rendering even in its current state, but breaks rendering on the 3D world map).

In the apparently rare cases where we hit issues that are caused by direct buffer mapping, we can simply disable it. Testing has proven that doing this globally is, however, a rather bad idea, as it negatively affects a lot of games in various degrees, some in a rather dramatic way.

I'll keep it as draft for a while until I can test it more extensively, but initial impressions are good and it does look a lot cleaner this way in the end.