### PR TITLE
[d3d8] Don't explicitly end scene during device reset

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -208,8 +208,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Reset(D3DPRESENT_PARAMETERS* pPresentationParameters) {
     StateChange();
-    // Resetting implicitly ends scenes started by BeginScene
-    GetD3D9()->EndScene();
 
     m_presentParams = *pPresentationParameters;
     ResetState();


### PR DESCRIPTION
We no longer need to do this in d3d8 during device reset since as of https://github.com/doitsujin/dxvk/commit/39c19e9299821d6a17a6270c101d253e795ad557 d3d9 does this for us anyway. Needless to say, it will need a rebase first to work properly.