### PR TITLE
[d3d8] Use D3DPOOL_SCRATCH in CreateImageSurface

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -434,14 +434,20 @@ namespace dxvk {
     return res;
   }
 
-  HRESULT STDMETHODCALLTYPE D3D8Device::CreateImageSurface(UINT Width, UINT Height, D3DFORMAT Format, IDirect3DSurface8** ppSurface) {
+  HRESULT STDMETHODCALLTYPE D3D8Device::CreateImageSurface(
+          UINT                Width,
+          UINT                Height,
+          D3DFORMAT           Format,
+          IDirect3DSurface8** ppSurface) {
+    // FIXME: Handle D3DPOOL_SCRATCH in CopyRects
+    D3DPOOL pool = isUnsupportedSurfaceFormat(Format) ? D3DPOOL_SCRATCH : D3DPOOL_SYSTEMMEM;
+
     Com<d3d9::IDirect3DSurface9> pSurf = nullptr;
     HRESULT res = GetD3D9()->CreateOffscreenPlainSurface(
       Width,
       Height,
       d3d9::D3DFORMAT(Format),
-      // FIXME: D3DPOOL_SCRATCH is said to be dx8 compatible, but currently won't work with CopyRects
-      d3d9::D3DPOOL_SYSTEMMEM,
+      d3d9::D3DPOOL(pool),
       &pSurf,
       NULL);
 

--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -15,6 +15,17 @@ namespace dxvk {
     return isDXT(D3DFORMAT(fmt));
   }
 
+  constexpr bool isUnsupportedSurfaceFormat(D3DFORMAT fmt) {
+    // mirror what dxvk doesn't support in terms of d3d9 surface formats
+    return fmt == D3DFMT_R8G8B8
+        || fmt == D3DFMT_R3G3B2
+        || fmt == D3DFMT_A8R3G3B2
+        || fmt == D3DFMT_A8P8
+        || fmt == D3DFMT_P8;
+        // not included in the d3d8 spec
+        //|| fmt == D3DFMT_CXV8U8;
+  }
+
   constexpr bool isSupportedDepthStencilFormat(D3DFORMAT fmt) {
     // native d3d8 doesn't support D3DFMT_D32, D3DFMT_D15S1 or D3DFMT_D24X4S4
     return fmt == D3DFMT_D16_LOCKABLE


### PR DESCRIPTION
Fixes #89 and fixes points (1.) and (2.) from #205.

Some games expect us to successfully create image surfaces for them even when they supply unsupported formats like `P8` or `R8G8B8`. This only works with `D3DPOOL_SCRATCH` according to spec, and it's also what dxvk validates inside of `CreateOffscreenPlainSurfaceEx()`.

We don't actually need to fully support them in order for the above games to work properly at least. #182 will still need `P8` support, since it uses that on `CreateTexture()`.

The only problem is we don't currently handle `D3DPOOL_SCRATCH` at all in `CopyRects()`, so this has the potential to explode and break more than it fixes. We should merge this change only after sorting out that bit ideally.