### PR TITLE
[d3d8] Validate depth stencil format use with CopyRects

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -570,6 +570,13 @@ namespace dxvk {
     src->GetD3D9()->GetDesc(&srcDesc);
     dst->GetD3D9()->GetDesc(&dstDesc);
 
+    // This method cannot be applied to surfaces whose formats
+    // are classified as depth stencil formats.
+    if (unlikely(isDepthStencilFormat(D3DFORMAT(srcDesc.Format)) ||
+                 isDepthStencilFormat(D3DFORMAT(dstDesc.Format)))) {
+      return D3DERR_INVALIDCALL;
+    }
+
     StateChange();
 
     // If pSourceRectsArray is NULL, then the entire surface is copied

--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -26,6 +26,16 @@ namespace dxvk {
         || fmt == D3DFMT_D24X8;
   }
 
+  constexpr bool isDepthStencilFormat(D3DFORMAT fmt) {
+    return fmt == D3DFMT_D16_LOCKABLE
+        || fmt == D3DFMT_D16
+        || fmt == D3DFMT_D32
+        || fmt == D3DFMT_D15S1
+        || fmt == D3DFMT_D24X4S4
+        || fmt == D3DFMT_D24S8
+        || fmt == D3DFMT_D24X8;
+  }
+
   // Get bytes per pixel (or 4x4 block for DXT)
   constexpr UINT getFormatStride(D3DFORMAT fmt) {
     switch (fmt) {


### PR DESCRIPTION
As of now `CopyRects()` succeeds in d8vk if invoked with depth stencil surfaces.

Upstream dxvk will soon add several [validations on StretchRect() calls](https://github.com/doitsujin/dxvk/pull/3895/commits/0f3826fcc92b09ca7b25ddb67d400f97d2bc45c4) in combination with depth stencils, which could interfere with its use on our end in `CopyRects()`, however the good news is that the d3d8 documentation states that:

> This method cannot be applied to surfaces whose formats are classified as depth stencil formats.

I have written a test, and it looks like WineD3D does indeed respect it, so we should as well, if only to avoid unnecessary d3d9 calls that are bound to fail in the future anyway.

Edit: Native Nvidia also does this validation.