### PR TITLE
[d3d8] Add a config option to hide programmable shader caps

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -36,14 +36,14 @@ namespace dxvk {
   }
 
   // (8<-9) D3DCAPSX: Writes to D3DCAPS8 from D3DCAPS9
-  inline void ConvertCaps8(const d3d9::D3DCAPS9& caps9, D3DCAPS8* pCaps8) {
+  inline void ConvertCaps8(const d3d9::D3DCAPS9& caps9, D3DCAPS8* pCaps8, const D3D8Options& options) {
 
     // should be aligned
     std::memcpy(pCaps8, &caps9, sizeof(D3DCAPS8));
 
     // Max supported shader model is PS 1.4 and VS 1.1
-    pCaps8->VertexShaderVersion = D3DVS_VERSION(1, 1);
-    pCaps8->PixelShaderVersion  = D3DPS_VERSION(1, 4);
+    pCaps8->VertexShaderVersion = options.programmableShaderCaps ? D3DVS_VERSION(1, 1) : D3DVS_VERSION(0, 0);
+    pCaps8->PixelShaderVersion  = options.programmableShaderCaps ? D3DPS_VERSION(1, 4) : D3DPS_VERSION(0, 0);
 
     // This was removed by D3D9. We can probably render windowed.
     pCaps8->Caps2       |= D3DCAPS2_CANRENDERWINDOWED;

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -159,7 +159,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D8Device::GetDeviceCaps(D3DCAPS8* pCaps) {
     d3d9::D3DCAPS9 caps9;
     HRESULT res = GetD3D9()->GetDeviceCaps(&caps9);
-    dxvk::ConvertCaps8(caps9, pCaps);
+    dxvk::ConvertCaps8(caps9, pCaps, m_d3d8Options);
     return res;
   }
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -131,7 +131,7 @@ namespace dxvk {
         D3DCAPS8* pCaps) {
       d3d9::D3DCAPS9 caps9;
       HRESULT res = m_d3d9->GetDeviceCaps(Adapter, (d3d9::D3DDEVTYPE)DeviceType, &caps9);
-      dxvk::ConvertCaps8(caps9, pCaps);
+      dxvk::ConvertCaps8(caps9, pCaps, m_d3d8Options);
       return res;
     }
 

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -28,12 +28,21 @@ namespace dxvk {
     /// May hurt performance outside of specifc games that benefit from it.
     bool batching = false;
 
+    /// Most D3D8 games provide a fallback rendering path that only uses fixed function
+    /// shaders, for compatibility with hardware that does not support programmable shaders,
+    /// namely D3D7 generation cards such as the GeForce 2, the GeForce 4 MX series etc.
+    ///
+    /// Disabling this option will hide VS/PS support in reported caps and is only useful
+    /// for fixed function debugging or, arguably, for nostalgia reasons
+    bool programmableShaderCaps = true;
+
     D3D8Options() {}
     D3D8Options(const Config& config) {
       int32_t minManagedSize  = config.getOption<int32_t>    ("d3d8.managedBufferPlacement", managedBufferPlacement);
       managedBufferPlacement  = config.getOption<bool>       ("d3d8.managedBufferPlacement", true) ? minManagedSize : UINT32_MAX;
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",  "");
+      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",            "");
       batching                = config.getOption<bool>       ("d3d8.batching",               batching);
+      programmableShaderCaps  = config.getOption<bool>       ("d3d8.programmableShaderCaps", programmableShaderCaps);
 
       parseVsDecl(forceVsDeclStr);
     }


### PR DESCRIPTION
Thought it would be a nice to have option for people who want to experience some d3d8 games as they looked on d3d7-capable hardware (first generation T&L), since most will have a fixed function fallback for this type of situation. I think some early d3d9 games may also have such fallbacks, but they would be notably more rare (and rather bizarre at that point), so I've kept this as a d3d8-only config option.

I guess it could also be used for debugging in some cases, for example NFS High Stakes 2 currently has broken fog with programmable shaders, but its fixed function fallback path renders fog correctly (albeit fixed function reflections and other effects are more primitive than their programmable counterparts).