### PR TITLE
[d3d8] Add a workaround for LotR: Fellowship of the Ring

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -300,6 +300,10 @@ namespace dxvk {
           IDirect3DTexture8** ppTexture) {
     InitReturnPtr(ppTexture);
 
+    // Nvidia & Intel workaround for The Lord of the Rings: The Fellowship of the Ring
+    if (m_d3d8Options.placeP8InScratch && Format == D3DFMT_P8)
+      Pool = D3DPOOL_SCRATCH;
+
     Com<d3d9::IDirect3DTexture9> pTex9 = nullptr;
     HRESULT res = GetD3D9()->CreateTexture(
       Width,

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -21,10 +21,24 @@ namespace dxvk {
     /// May hurt performance outside of specifc games that benefit from it.
     bool batching = false;
 
+    /// The Lord of the Rings: The Fellowship of the Ring tries to create a P8 texture
+    /// in D3DPOOL_MANAGED on Nvidia and Intel, which fails, but has a separate code
+    /// path for ATI/AMD that creates it in D3DPOOL_SCRATCH instead, which works.
+    ///
+    /// The internal logic determining this path doesn't seem to be d3d-related, but
+    /// the game works universally if we mimic its own ATI/AMD workaround during P8
+    /// texture creation.
+    ///
+    /// Early Nvidia GPUs, such as the GeForce 4 generation cards, included and exposed
+    /// P8 texture support. However, it was no longer advertised with cards in the FX series
+    /// and above. Most likely ATI/AMD drivers never supported P8 in the first place.
+    bool placeP8InScratch = false;
+
     D3D8Options() {}
     D3D8Options(const Config& config) {
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",  "");
+      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",            "");
       batching                = config.getOption<bool>       ("d3d8.batching",               batching);
+      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",       placeP8InScratch);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1109,6 +1109,12 @@ namespace dxvk {
     { R"(\\X2\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* The Lord of the Rings:                     *
+     * The Fellowship of the Ring                 */
+    { R"(\\Fellowship\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+      { "d3d8.placeP8InScratch",            "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #182. I've summed it up in the description for the new config option I added, but this is essentially a game bug that manifests itself even on Windows with Nvidia & Intel:

> 
>     /// The Lord of the Rings: The Fellowship of the Ring tries to create a P8 texture
>     /// in D3DPOOL_MANAGED on Nvidia and Intel, which fails, but has a separate code 
>     /// path for ATI/AMD that creates it in D3DPOOL_SCRATCH instead, which works.
>     ///
>     /// The internal logic determining this path doesn't seem to be d3d-related, but 
>     /// the game works universally if we mimic its own ATI/AMD workaround during P8 
>     /// texture creation.
>     ///
>     /// There's some indication early Nvidia drivers included P8 texture support,
>     /// but that it was removed at some point along with the launch of its FX series of
>     /// cards. Most likely ATI/AMD drivers never supported P8 in the first place.

It's a config option because, as mentioned previously, not even native Nvidia drivers support P8 textures ([for a while now, allegedly](https://forums.guru3d.com/threads/lotr-fellowship-of-the-ring-unplayable.142048/)) and other games might depend on calls to CreateTexture() failing, since we don't actually expose support for P8.

This PR will most likely have conflicts with other PRs I have open, but I can rebase when we start merging them.