### PR TITLE
[d3d8] Return S_FALSE if VCache queries are unsupported

### DIFF
--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -179,6 +179,13 @@ namespace d3d9 {
 #define D3DDEVINFOID_VCACHE            4
 #endif
 
+typedef struct D3DDEVINFO_VCACHE {
+  DWORD         Pattern;
+  DWORD         OptMethod;
+  DWORD         CacheSize;
+  DWORD         MagicNumber;
+} D3DDEVINFO_VCACHE;
+
 // MinGW headers are broken. Who'dve guessed?
 #ifndef _MSC_VER
 


### PR DESCRIPTION
Related to https://github.com/doitsujin/dxvk/pull/4020. While testing the behavior on native platforms, I uncovered the fact that native drivers actually adhered to spec and returned S_FALSE when VCache queries are unsupported.

Additionally, both modern AMD drivers and ATI native drivers of old (on WinXP) zero out the return struct:

```
Listing VCache query result:
  ~ Response: S_FALSE
  ~ Pattern: 0
  ~ OptMethod: 0
  ~ CacheSize: 0
  ~ MagicNumber: 0
```

The behavior on Nvidia is correct and we should be inline with what d3d9 returns.

I'm not entirely sure if I've implemented this correctly, but I rather added the D3DDEVINFO_VCACHE struct declaration to our headers than messing about with D3D9Types.h. Let me know if that's a problem.